### PR TITLE
Override default constructor property for class Laps

### DIFF
--- a/fastf1/core.py
+++ b/fastf1/core.py
@@ -669,6 +669,10 @@ class Laps(pd.DataFrame):
 
     QUICKLAP_THRESHOLD = 1.07
 
+    @property
+    def _constructor(self):
+        return Laps
+
     def __pick_wrap(func):
         @functools.wraps(func)
         def decorator(*args, **kwargs):


### PR DESCRIPTION
Currently, manipulation results of Laps will be of type DataFrame as this is the parent class of Laps.
This leads to problems with for example
`Laps.filter(['Time', 'Driver', 'LapTime'])`

Pandas expects the result to have the same DataType as self. This is checked in `Laps._ensure_type()` before returning the result. 
An AssertionError is raised here because the resulting DataFrame is not an instance of Laps.

Overriding the constructor will cause the result of `.filter()` to be an instance of Laps too. 
See [https://pandas.pydata.org/pandas-docs/stable/development/extending.html#override-constructor-properties](url)

Disadvantage of this approach: Some `Laps.pick_...()` functions can obviously fail after filtering.
An alternative would be, to override `Laps._ensure_type()` to allow the result of `Laps.filter()` to be a DataFrame. But this would miss out completely on the convenience of the pick functions.


